### PR TITLE
Fixing Spanish name inside *.desktop launcher.

### DIFF
--- a/src/qt6ct/qt6ct.desktop
+++ b/src/qt6ct/qt6ct.desktop
@@ -25,11 +25,11 @@ Name[de]=Qt6-Einstellungen
 Comment[el]=Εργαλείο διαμόρφωσης της Qt6
 Name[el]=Ρυθμίσεις Qt6
 
-Comment[es]=Herramienta de configuración de QT5
-Name[es]=Ajustes QT5
+Comment[es]=Herramienta de configuración de Qt6
+Name[es]=Ajustes Qt6
 
-Comment[es_ES]=Herramienta de configuración de QT5
-Name[es_ES]=Ajustes QT6
+Comment[es_ES]=Herramienta de configuración de Qt6
+Name[es_ES]=Ajustes Qt6
 
 Name[fi]=Qt6 asetukset
 


### PR DESCRIPTION
Launcher called the application "Qt5 Settings" instead of "Qt6 Settings" in Spanish.