### PR TITLE
Add compatibility with QT_STYLE_OVERRIDE=qt5ct-style

### DIFF
--- a/src/qt6ct-style/plugin.cpp
+++ b/src/qt6ct-style/plugin.cpp
@@ -40,7 +40,7 @@ public:
 
 QStyle *Qt6CTStylePlugin::create(const QString &key)
 {
-    if (key == "qt6ct-style")
+    if (key == "qt6ct-style" || key == "qt5ct-style")
         return new Qt6CTProxyStyle();
     return nullptr;
 }

--- a/src/qt6ct-style/qt6ct.json
+++ b/src/qt6ct-style/qt6ct.json
@@ -1,3 +1,3 @@
 {
-    "Keys": [ "qt6ct-style" ]
+    "Keys": [ "qt6ct-style", "qt5ct-style' ]
 }

--- a/src/qt6ct-style/qt6ct.json
+++ b/src/qt6ct-style/qt6ct.json
@@ -1,3 +1,3 @@
 {
-    "Keys": [ "qt6ct-style", "qt5ct-style' ]
+    "Keys": [ "qt6ct-style", "qt5ct-style" ]
 }


### PR DESCRIPTION
Hello! For one reason or another, I want to be able to set the qt6ct's style without changing the platform, this is largely so i can apply custom styles while still using the Qgnomeplatform Platform theme so Qt apps will follow GNOME's font settings, etc etc.

This patch allows `QT_STYLE_OVERRIDE=qt5ct-style` to apply the style