### PR TITLE
Fix default palette

### DIFF
--- a/src/qt6ct-qtplugin/qt6ctplatformtheme.cpp
+++ b/src/qt6ct-qtplugin/qt6ctplatformtheme.cpp
@@ -181,7 +181,7 @@ void Qt6CTPlatformTheme::applySettings()
         }
 
         if(!m_palette)
-            m_palette = std::make_unique<QPalette>(*QGenericUnixTheme::palette(QPlatformTheme::SystemPalette));
+            m_palette = std::make_unique<QPalette>(qApp->style()->standardPalette());
 
         if(m_update && m_usePalette)
             qApp->setPalette(*m_palette);


### PR DESCRIPTION
Use a default palette from the selected style, instead of asking QGenericUnixTheme for a system palette, which doesn't seem to work at all outside KDE.

Fixes #35 