### PR TITLE
Remove .desktop suffix when calling setDesktopFileName

### DIFF
--- a/src/qt6ct/main.cpp
+++ b/src/qt6ct/main.cpp
@@ -38,7 +38,7 @@
 int main(int argc, char **argv)
 {
     QApplication app(argc, argv);
-    QGuiApplication::setDesktopFileName(QStringLiteral("qt6ct.desktop"));
+    QGuiApplication::setDesktopFileName(QStringLiteral("qt6ct"));
 
     QTranslator translator;
 


### PR DESCRIPTION
Currently we get this warning from Qt6.
```
QGuiApplication::setDesktopFileName: the specified desktop file name ends with .desktop. For compatibility reasons, the .desktop suffix will be removed. Please specify a desktop file name without .desktop suffix
```

This is because Qt6 expects the `desktopFileName` to be just the file name of the desktop without path or `.desktop` suffix.
> This is the file name, without the full path or the trailing ".desktop" extension of the desktop entry that represents this application according to the freedesktop desktop entry specification.

This PR removes the `.desktop` suffix