### PR TITLE
Apply new platform palette without overriding app palette

### DIFF
--- a/src/qt6ct-qtplugin/qt6ctplatformtheme.h
+++ b/src/qt6ct-qtplugin/qt6ctplatformtheme.h
@@ -80,7 +80,7 @@ private:
 #endif
     QString loadStyleSheets(const QStringList &paths);
     QString m_style, m_iconTheme, m_userStyleSheet, m_prevStyleSheet;
-    std::unique_ptr<QPalette> m_palette;
+    QPalette m_palette;
     QFont m_generalFont, m_fixedFont;
     int m_doubleClickInterval;
     int m_cursorFlashTime;
@@ -88,7 +88,6 @@ private:
     int m_buttonBoxLayout;
     int m_keyboardScheme;
     bool m_update = false;
-    bool m_usePalette = true;
     int m_toolButtonStyle = Qt::ToolButtonFollowStyle;
     int m_wheelScrollLines = 3;
     bool m_showShortcutsInContextMenus = false;


### PR DESCRIPTION
Currently when a palette is set by qt6ct, it can in some cases override an app-specific palette. It would be nice if qt6ct would only set the platform palette (i.e. QPlatformTheme::SystemPalette) and still allow apps to set/adjust their own palette when desired.

Test case: start Audacious and select Dark theme in Audacious settings. Then in qt6ct configuration, select "dusk" or "sand" color scheme. It partially applies to Audacious (where it should not) and you end up with an unusable mix of Audacious's color scheme and qt6ct's.

Port of the qt5ct patch from https://sourceforge.net/p/qt5ct/tickets/97/. I have been using the patch in both qt5ct and qt6ct for quite some time and have not seen any ill side effects.