### PR TITLE
Use QWindowSystemInterface::handleThemeChange

### DIFF
--- a/src/qt6ct-qtplugin/CMakeLists.txt
+++ b/src/qt6ct-qtplugin/CMakeLists.txt
@@ -9,5 +9,5 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 
 add_library(qt6ct-qtplugin MODULE ${app_SRCS})
 set_target_properties(qt6ct-qtplugin PROPERTIES OUTPUT_NAME qt6ct)
-target_link_libraries(qt6ct-qtplugin PRIVATE Qt6::Widgets Qt6::GuiPrivate qt6ct-common)
+target_link_libraries(qt6ct-qtplugin PRIVATE Qt6::WidgetsPrivate Qt6::GuiPrivate qt6ct-common)
 install(TARGETS qt6ct-qtplugin DESTINATION ${PLUGINDIR}/platformthemes)

--- a/src/qt6ct-qtplugin/qt6ct-qtplugin.pro
+++ b/src/qt6ct-qtplugin/qt6ct-qtplugin.pro
@@ -11,7 +11,7 @@ SOURCES += \
     qt6ctplatformtheme.cpp
 
 !equals(DISABLE_WIDGETS,1) {
-   QT += widgets
+   QT += widgets widgets-private
 }
 
 OTHER_FILES += qt6ct.json

--- a/src/qt6ct-qtplugin/qt6ctplatformtheme.cpp
+++ b/src/qt6ct-qtplugin/qt6ctplatformtheme.cpp
@@ -41,22 +41,28 @@
 #include <QStyleFactory>
 #include <QApplication>
 #include <QWidget>
+#if QT_CONFIG(graphicsview)
+#include <QGraphicsScene>
+#endif
+#include <private/qapplication_p.h>
 #endif
 #include <QFile>
 #include <QFileSystemWatcher>
-#include <private/qiconloader_p.h>
 
 #include "qt6ct.h"
 #include "qt6ctplatformtheme.h"
 
 #include <QStringList>
 #include <qpa/qplatformthemefactory_p.h>
+#include <qpa/qwindowsysteminterface.h>
 
 Q_LOGGING_CATEGORY(lqt6ct, "qt6ct", QtWarningMsg)
 
 //QT_QPA_PLATFORMTHEME=qt6ct
 
-Qt6CTPlatformTheme::Qt6CTPlatformTheme()
+Qt6CTPlatformTheme::Qt6CTPlatformTheme() :
+    m_generalFont(*QGenericUnixTheme::font(QPlatformTheme::SystemFont)),
+    m_fixedFont(*QGenericUnixTheme::font(QPlatformTheme::FixedFont))
 {
     Qt6CT::initConfig();
     if(QGuiApplication::desktopSettingsAware())
@@ -66,7 +72,6 @@ Qt6CTPlatformTheme::Qt6CTPlatformTheme()
 #ifdef QT_WIDGETS_LIB
         QMetaObject::invokeMethod(this, "createFSWatcher", Qt::QueuedConnection);
 #endif
-        QGuiApplication::setFont(m_generalFont);
     }
     qCDebug(lqt6ct) << "using qt6ct plugin";
 #ifdef QT_WIDGETS_LIB
@@ -93,7 +98,7 @@ QPlatformDialogHelper *Qt6CTPlatformTheme::createPlatformDialogHelper(DialogType
 const QPalette *Qt6CTPlatformTheme::palette(QPlatformTheme::Palette type) const
 {
     qDebug() << Q_FUNC_INFO << type;
-    return (m_usePalette && m_palette) ? m_palette.get() : QGenericUnixTheme::palette(type);
+    return m_palette ? m_palette.get() : QGenericUnixTheme::palette(type);
 }
 
 const QFont *Qt6CTPlatformTheme::font(QPlatformTheme::Font type) const
@@ -152,41 +157,19 @@ void Qt6CTPlatformTheme::applySettings()
 {
     if(!QGuiApplication::desktopSettingsAware() || m_isIgnored)
     {
-        m_usePalette = false;
         m_update = true;
         return;
     }
 
-    if(!m_update)
-    {
-        //do not override application palette
-        if(QCoreApplication::testAttribute(Qt::AA_SetPalette))
-        {
-            m_usePalette = false;
-            qCDebug(lqt6ct) << "palette support is disabled";
-        }
-    }
-
-    QGuiApplication::setFont(m_generalFont); //apply font
-
 #ifdef QT_WIDGETS_LIB
     if(hasWidgets())
     {
-        qApp->setFont(m_generalFont);
-
-        //Qt 5.6 or higher should be use themeHint function on application startup.
-        //So, there is no need to call this function first time.
         if(m_update)
         {
-            qApp->setWheelScrollLines(m_wheelScrollLines);
+            if(FontHash *hash = qt_app_fonts_hash(); hash && hash->size())
+                hash->clear();
             Qt6CT::reloadStyleInstanceSettings();
         }
-
-        if(!m_palette)
-            m_palette = std::make_unique<QPalette>(qApp->style()->standardPalette());
-
-        if(m_update && m_usePalette)
-            qApp->setPalette(*m_palette);
 
         if(m_userStyleSheet != m_prevStyleSheet)
         {
@@ -209,18 +192,21 @@ void Qt6CTPlatformTheme::applySettings()
 #endif
 
     if(m_update)
-        QIconLoader::instance()->updateSystemTheme(); //apply icons
+    {
+        QWindowSystemInterface::handleThemeChange();
+        QCoreApplication::postEvent(qGuiApp, new QEvent(QEvent::ApplicationFontChange));
+    }
 
 #ifdef QT_WIDGETS_LIB
     if(hasWidgets() && m_update)
     {
-        for(QWidget *w : qApp->allWidgets())
-        {
-            QEvent e(QEvent::ThemeChange);
-            QApplication::sendEvent(w, &e);
-            if(m_palette && m_usePalette)
-                w->setPalette(*m_palette);
-        }
+#if QT_CONFIG(graphicsview)
+        for(auto scene : std::as_const(QApplicationPrivate::instance()->scene_list))
+            QCoreApplication::postEvent(scene, new QEvent(QEvent::ApplicationFontChange));
+#endif
+
+        for(QWidget *w : QApplication::allWidgets())
+            QCoreApplication::postEvent(w, new QEvent(QEvent::ThemeChange));
     }
 #endif
 
@@ -257,7 +243,7 @@ void Qt6CTPlatformTheme::readSettings()
     settings.beginGroup("Appearance");
     m_style = settings.value("style", "Fusion").toString();
     QString schemePath = settings.value("color_scheme_path").toString();
-    if(!schemePath.isEmpty() && settings.value("custom_palette", false).toBool())
+    if(!m_isIgnored && !schemePath.isEmpty() && settings.value("custom_palette", false).toBool())
     {
         schemePath = Qt6CT::resolvePath(schemePath); //replace environment variables
         m_palette = std::make_unique<QPalette>(Qt6CT::loadColorScheme(schemePath, *QPlatformTheme::palette(SystemPalette)));
@@ -279,10 +265,10 @@ void Qt6CTPlatformTheme::readSettings()
     settings.endGroup();
 
     settings.beginGroup("Fonts");
-    m_generalFont = QGuiApplication::font();
-    m_generalFont.fromString(settings.value("general", QGuiApplication::font()).toString());
-    m_fixedFont = QGuiApplication::font();
-    m_fixedFont.fromString(settings.value("fixed", QGuiApplication::font()).toString());
+    m_generalFont = *QGenericUnixTheme::font(QPlatformTheme::SystemFont);
+    m_generalFont.fromString(settings.value("general").toString());
+    m_fixedFont = *QGenericUnixTheme::font(QPlatformTheme::FixedFont);
+    m_fixedFont.fromString(settings.value("fixed").toString());
     settings.endGroup();
 
     settings.beginGroup("Interface");
@@ -338,8 +324,6 @@ void Qt6CTPlatformTheme::readSettings()
             QCoreApplication::setAttribute(Qt::AA_ForceRasterWidgets, true);
         else if(!m_isIgnored && forceRasterWidgets == Qt::Unchecked)
             QCoreApplication::setAttribute(Qt::AA_ForceRasterWidgets, false);
-        if(m_isIgnored)
-            m_usePalette = false;
         settings.endGroup();
     }
 }

--- a/src/qt6ct-qtplugin/qt6ctplatformtheme.h
+++ b/src/qt6ct-qtplugin/qt6ctplatformtheme.h
@@ -88,7 +88,6 @@ private:
     int m_buttonBoxLayout;
     int m_keyboardScheme;
     bool m_update = false;
-    bool m_usePalette = true;
     int m_toolButtonStyle = Qt::ToolButtonFollowStyle;
     int m_wheelScrollLines = 3;
     bool m_showShortcutsInContextMenus = false;


### PR DESCRIPTION
This replaces explicit calls of various setters with a single QWindowSystemInterface::handleThemeChange call that properly asks Qt to re-request the settings from plugin without overriding settings set by application.

This also removes default QFont constructor calls as it calls QGuiApplication::font under the hood what makes it initialize with the wrong font as Qt6CTPlatformTheme is not finished yet